### PR TITLE
Update and Issue #17 Fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,9 +34,9 @@ minecraft {
 }
     
 dependencies {
-	compile files("/libs/Thaumcraft-1.7.10-4.2.3.0.jar")
-    compile 'net.sengir.forestry:forestry_1.7.10:3.3.0.415-unstable:dev'
-	compile files("/libs/BloodMagic-1.7.10-1.3.0a-1.jar")
+	compile files("/libs/Thaumcraft-1.7.10-4.2.3.4.jar")
+    compile 'net.sengir.forestry:forestry_1.7.10:3.4.0.7:dev'
+	compile files("/libs/BloodMagic-1.7.10-1.3.0b-3.jar")
 }
 
 processResources

--- a/src/main/java/magicbees/bees/Allele.java
+++ b/src/main/java/magicbees/bees/Allele.java
@@ -84,8 +84,8 @@ public class Allele implements IAllele
 					new int[] { 60, 2 });
 			
 			Allele.spawnWispOrHecate = new AlleleEffectSpawnMobWeighted("AMWisp", true, 20,
-					new String[] { ArsMagicaHelper.Name + ".MobWisp", ArsMagicaHelper.Name + ".MobHecate" },
-					new int[] { 40, 3 });
+					new String[] { ArsMagicaHelper.Name + ".MobHecate" },
+					new int[] { 10 });
 		}
 		else
 		{

--- a/src/main/java/magicbees/bees/BeeMutation.java
+++ b/src/main/java/magicbees/bees/BeeMutation.java
@@ -498,7 +498,7 @@ public class BeeMutation implements IBeeMutation
 					conditions.add(String.format(LocalizationManager.getLocalizedString("research.requiresBlock"), ores.get(0).getDisplayName()));
 				}
 			}
-			else
+			else if (requiredBlock != null)
 			{
 				int meta = 0;
 				if (this.requiredBlockMeta != OreDictionary.WILDCARD_VALUE)

--- a/src/main/java/magicbees/main/MagicBees.java
+++ b/src/main/java/magicbees/main/MagicBees.java
@@ -59,6 +59,8 @@ public class MagicBees
 	public void init(FMLInitializationEvent event)
 	{
 		ModHelper.init();
+		
+		BeeManager.ititializeBees();
 
 		LogHelper.info("Init completed");
 	}
@@ -72,8 +74,6 @@ public class MagicBees
 		NetworkRegistry.INSTANCE.registerGuiHandler(this, this.guiHandler);
 
 		proxy.registerRenderers();
-
-		BeeManager.ititializeBees();
 
 		this.modConfig.saveConfigs();
 


### PR DESCRIPTION
Bump dependencies to last stable versions of Forestry, Thaumcraft, and Blood Magic.
Closes #17 - Loads bees during init(), also fixes potential NPE with this move for GenDustry.