### PR TITLE
Fixed NullPointerException bug for ghastly bees

### DIFF
--- a/src/main/java/magicbees/bees/allele/effect/AlleleEffectSpawnMobWeighted.java
+++ b/src/main/java/magicbees/bees/allele/effect/AlleleEffectSpawnMobWeighted.java
@@ -51,6 +51,9 @@ public class AlleleEffectSpawnMobWeighted extends AlleleEffect {
 			if (roll < this.spawnChance[i]) {
 				flag = true;
 				Entity mob = EntityList.createEntityByName(this.entityNames[i], w);
+				// .createEntityByName method returns null when spawning a ghast in the overworld
+				if(mob == null)
+					return false;
 				double[] coords = this.randomMobSpawnCoords(w, genome, housing);
 
 				mob.setPositionAndRotation(coords[0], coords[1], coords[2], w.rand.nextFloat() * 360f, 0f);


### PR DESCRIPTION
After breeding ghastly bees (possibly others) in the overworld for a while, server crashed with a NullPointerException every time the chunk with the apiary was loaded. Seems that EntityList.createEntityByName() will return null when spawning a ghast in the overworld. Just added a null check to the mob variable before performing any operations on it. If these bees are only to be bred in the Nether adding a check for that would also fix it, but the null check isn't a bad idea :) Oddly enough, after fixing this the ghast spawned just fine.