### PR TITLE
Fix for bee name changes in resource packs

### DIFF
--- a/src/main/java/magicbees/main/utils/LocalizationManager.java
+++ b/src/main/java/magicbees/main/utils/LocalizationManager.java
@@ -6,21 +6,13 @@ public class LocalizationManager
 {
 	public static String getLocalizedString(String key)
 	{
-		String result = LanguageRegistry.instance().getStringLocalization(key);
-		if (result.isEmpty())
-		{
-			result = LanguageRegistry.instance().getStringLocalization(key, "en_US");
-		}
-		return result;
+		if(StatCollector.canTranslate(key)) return StatCollector.translateToLocal(key);
+		else return StatCollector.translateToFallback(key);
 	}
 
 	public static String getLocalizedString(String key, Object... objects)
 	{
-		String result = LanguageRegistry.instance().getStringLocalization(key);
-		if (result.isEmpty())
-		{
-			result = LanguageRegistry.instance().getStringLocalization(key, "en_US");
-		}
-		return String.format(result, objects);
+		if(StatCollector.canTranslate(key)) return String.format(StatCollector.translateToLocal(key), objects);
+		else return String.format(StatCollector.translateToFallback(key), objects);
 	}
 }

--- a/src/main/java/magicbees/main/utils/LocalizationManager.java
+++ b/src/main/java/magicbees/main/utils/LocalizationManager.java
@@ -6,13 +6,25 @@ public class LocalizationManager
 {
 	public static String getLocalizedString(String key)
 	{
-		if(StatCollector.canTranslate(key)) return StatCollector.translateToLocal(key);
-		else return StatCollector.translateToFallback(key);
+		if(StatCollector.canTranslate(key))
+		{
+			return StatCollector.translateToLocal(key);
+		}
+		else
+		{
+			return StatCollector.translateToFallback(key);
+		}
 	}
 
 	public static String getLocalizedString(String key, Object... objects)
 	{
-		if(StatCollector.canTranslate(key)) return String.format(StatCollector.translateToLocal(key), objects);
-		else return String.format(StatCollector.translateToFallback(key), objects);
+		if(StatCollector.canTranslate(key))
+		{
+			return String.format(StatCollector.translateToLocal(key), objects);
+		}
+		else
+		{
+			return String.format(StatCollector.translateToFallback(key), objects);
+		}
 	}
 }


### PR DESCRIPTION
StatCollector includes language files from resource packs, and should be used over LanguageRegistry which only includes language files from mod jars.