### PR TITLE
Simply Jetpacks Compat

### DIFF
--- a/src/main/java/magicbees/bees/BeeMutation.java
+++ b/src/main/java/magicbees/bees/BeeMutation.java
@@ -297,9 +297,19 @@ public class BeeMutation {
 			beeMutationFactory.createMutation(Allele.getBaseSpecies("Frugal"), BeeSpecies.MUTABLE.getSpecies(), BeeSpecies.EE_MINIUM.getGenome(), 8);
 		}
 		
-		if (RedstoneArsenalHelper.isActive()) {
-			beeMutationFactory.createMutation(BeeSpecies.TE_ELECTRUM.getSpecies(), BeeSpecies.TE_DESTABILIZED.getSpecies(), BeeSpecies.RSA_FLUXED.getGenome(), 10)
-					.requireResource("blockElectrumFlux");
+		if (ThermalModsHelper.isActive()) {
+			baseB = BeeSpecies.TE_DESTABILIZED.getSpecies();
+		} else if (ThaumcraftHelper.isActive()){
+			baseB = BeeSpecies.TC_ORDER.getSpecies();
+		} else {
+			BeeSpecies.RSA_FLUXED.setInactive();
+		}
+		if (BeeSpecies.RSA_FLUXED.isActive()) {
+			baseA = (BeeSpecies.TE_ELECTRUM.isActive()) ? BeeSpecies.TE_ELECTRUM.getSpecies() : BeeSpecies.GOLD.getSpecies();
+			mutation = beeMutationFactory.createMutation(baseA, baseB , BeeSpecies.RSA_FLUXED.getGenome(), 10);
+			if(RedstoneArsenalHelper.isActive()){
+				mutation.requireResource("blockElectrumFlux");
+			}
 		}
 		
 		if (ThermalModsHelper.isActive()) {

--- a/src/main/java/magicbees/bees/BeeProductHelper.java
+++ b/src/main/java/magicbees/bees/BeeProductHelper.java
@@ -388,6 +388,10 @@ public class BeeProductHelper {
 		
 		if (RedstoneArsenalHelper.isActive()) {
 			RSA_FLUXED.addSpecialty(RedstoneArsenalHelper.fluxNugget, 0.9f);
+		} else if (OreDictionary.getOres("nuggetElectrumFlux").size() > 0){
+			RSA_FLUXED.addSpecialty(OreDictionary.getOres("nuggetElectrumFlux").get(0), 0.9f);
+		} else {
+			RSA_FLUXED.setInactive();
 		}
 	}
 	

--- a/src/main/java/magicbees/bees/BeeSpecies.java
+++ b/src/main/java/magicbees/bees/BeeSpecies.java
@@ -515,9 +515,6 @@ public enum BeeSpecies
 		}
 
 		BeeProductHelper.initRedstoneArsenelProducts();
-		if (!RedstoneArsenalHelper.isActive()) {
-			RSA_FLUXED.setInactive();
-		}
 
 		BeeProductHelper.initBotaniaProducts();
 		if (!BotaniaHelper.isActive()) {

--- a/src/main/java/magicbees/bees/BeeSpecies.java
+++ b/src/main/java/magicbees/bees/BeeSpecies.java
@@ -1,5 +1,6 @@
 package magicbees.bees;
 
+import magicbees.main.Config;
 import magicbees.main.utils.compat.AppliedEnergisticsHelper;
 import magicbees.main.utils.compat.ArsMagicaHelper;
 import magicbees.main.utils.compat.BotaniaHelper;
@@ -515,6 +516,9 @@ public enum BeeSpecies
 		}
 
 		BeeProductHelper.initRedstoneArsenelProducts();
+		if ( !Config.redstoneArsenalActive){
+			RSA_FLUXED.setInactive();
+		}
 
 		BeeProductHelper.initBotaniaProducts();
 		if (!BotaniaHelper.isActive()) {


### PR DESCRIPTION
Loosen RSA_FLUXED bee to produce the knock-off Fluxed Electrum nugget from Simply Jetpacks when RedstoneArsenal is not present.

Fuzzy breeding requirements since NEITHER RSA nor SJ actually lists ThermalMods as required in dependencies.