### PR TITLE
Changed oredict entry for Emerald, Diamond and Apatite shards

### DIFF
--- a/src/main/java/magicbees/main/Config.java
+++ b/src/main/java/magicbees/main/Config.java
@@ -387,7 +387,7 @@ public class Config
 			item = type.toString().toLowerCase();
 			item = Character.toString(item.charAt(0)).toUpperCase() + item.substring(1);
 			if (OreDictionary.getOres("ingot" + item).size() <= 0) {
-				if (OreDictionary.getOres("shard" + item).size() <= 0) {
+				if (OreDictionary.getOres("nugget" + item).size() <= 0) {
 					LogHelper.info("Disabled nugget " + type.toString());
 					type.setInactive();
 				}
@@ -411,9 +411,9 @@ public class Config
 		OreDictionary.registerOre("nuggetTin", nuggets.getStackForType(NuggetType.TIN));
 		OreDictionary.registerOre("nuggetSilver", nuggets.getStackForType(NuggetType.SILVER));
 		OreDictionary.registerOre("nuggetLead", nuggets.getStackForType(NuggetType.LEAD));
-		OreDictionary.registerOre("shardDiamond", nuggets.getStackForType(NuggetType.DIAMOND));
-		OreDictionary.registerOre("shardEmerald", nuggets.getStackForType(NuggetType.EMERALD));
-		OreDictionary.registerOre("shardApatite", nuggets.getStackForType(NuggetType.APATITE));
+		OreDictionary.registerOre("nuggetDiamond", nuggets.getStackForType(NuggetType.DIAMOND));
+		OreDictionary.registerOre("nuggetEmerald", nuggets.getStackForType(NuggetType.EMERALD));
+		OreDictionary.registerOre("nuggetApatite", nuggets.getStackForType(NuggetType.APATITE));
 	}
 	
 	private void setupBotaniaItems() {

--- a/src/main/java/magicbees/main/utils/CraftingManager.java
+++ b/src/main/java/magicbees/main/utils/CraftingManager.java
@@ -319,12 +319,12 @@ public class CraftingManager {
 
 		GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(Items.diamond),
 				"xxx", "xxx", "xxx",
-				'x', "shardDiamond"
+				'x', "nuggetDiamond"
 		));
 
 		GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(Items.emerald),
 				"xxx", "xxx", "xxx",
-				'x', "shardEmerald"
+				'x', "nuggetEmerald"
 		));
 
 		GameRegistry.addRecipe(new ShapedOreRecipe(ItemInterface.getItemStack("apatite"),


### PR DESCRIPTION
Changed them to nugget (in the ordict tag) to fix issues with other mods that are autogenerating recipes depending on the oreDict tag.

Shard is taken by Thaumcraft/Mekanism - converts into 1 dust
Shard in Magic Bees is Nugget, since 9 "shards" = 1 gem (Diamond, Apatite, Emerald).

Fixes #138 